### PR TITLE
Fix "__declspec attributes are not enabled" compile errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.ruby
 /.openssl
 /.build
+/.headers
 /CRuby
 
 .DS_Store

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# -*- mode: ruby; coding: utf-8 -*-
+# -*- mode: ruby -*-
 
 
 require 'open-uri'

--- a/Rakefile
+++ b/Rakefile
@@ -215,17 +215,19 @@ file PREBUILT_ARCHIVE do
 end
 
 
-task :headers_patch_dir => RUBY_CONFIGURE do
-  sh %( cp -r "#{RUBY_DIR}/include" #{HEADERS_PATCH_DEV_DIR} )
-  chdir HEADERS_PATCH_DEV_DIR do
-    sh %( git init && git add . && git commit -m '-' )
-    sh %( patch -p1 -d . < #{HEADERS_PATCH} )
+namespace :headers_patch do
+  task :setup => RUBY_CONFIGURE do
+    sh %( cp -r "#{RUBY_DIR}/include" #{HEADERS_PATCH_DEV_DIR} )
+    chdir HEADERS_PATCH_DEV_DIR do
+      sh %( git init && git add . && git commit -m '-' )
+      sh %( patch -p1 -d . < #{HEADERS_PATCH} )
+    end
   end
-end
 
-task :update_headers_patch do
-  chdir HEADERS_PATCH_DEV_DIR do
-    sh %( git diff > #{HEADERS_PATCH} )
+  task :update do
+    chdir HEADERS_PATCH_DEV_DIR do
+      sh %( git diff > #{HEADERS_PATCH} )
+    end
   end
 end
 

--- a/headers.patch
+++ b/headers.patch
@@ -1,0 +1,38 @@
+diff --git a/ruby/internal/attr/noalias.h b/ruby/internal/attr/noalias.h
+index 63324b7..6943d76 100644
+--- a/ruby/internal/attr/noalias.h
++++ b/ruby/internal/attr/noalias.h
+@@ -50,7 +50,7 @@
+ 
+ /** Wraps (or simulates) `__declspec((noalias))` */
+ #if RBIMPL_HAS_DECLSPEC_ATTRIBUTE(noalias)
+-# define RBIMPL_ATTR_NOALIAS() __declspec(noalias)
++# define RBIMPL_ATTR_NOALIAS()
+ #else
+ # define RBIMPL_ATTR_NOALIAS() /* void */
+ #endif
+diff --git a/ruby/internal/attr/noreturn.h b/ruby/internal/attr/noreturn.h
+index f741167..86b5fee 100644
+--- a/ruby/internal/attr/noreturn.h
++++ b/ruby/internal/attr/noreturn.h
+@@ -26,7 +26,7 @@
+ 
+ /** Wraps (or simulates) `[[noreturn]]` */
+ #if RBIMPL_HAS_DECLSPEC_ATTRIBUTE(noreturn)
+-# define RBIMPL_ATTR_NORETURN() __declspec(noreturn)
++# define RBIMPL_ATTR_NORETURN()
+ 
+ #elif RBIMPL_HAS_ATTRIBUTE(noreturn)
+ # define RBIMPL_ATTR_NORETURN() __attribute__((__noreturn__))
+diff --git a/ruby/internal/core/rbasic.h b/ruby/internal/core/rbasic.h
+index a6093c0..3c771c8 100644
+--- a/ruby/internal/core/rbasic.h
++++ b/ruby/internal/core/rbasic.h
+@@ -43,7 +43,6 @@
+ enum ruby_rvalue_flags { RVALUE_EMBED_LEN_MAX = 3 };
+ 
+ struct
+-RUBY_ALIGNAS(SIZEOF_VALUE)
+ RBasic {
+     VALUE flags;                /**< @see enum ::ruby_fl_type. */
+     const VALUE klass;


### PR DESCRIPTION
Apply patch to ruby headers to disable macros using __declspec.