### PR TITLE
Enable YJIT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,13 @@ jobs:
           sudo xcode-select -s '/Applications/Xcode_13.4.1.app/Contents/Developer'
           xcodebuild -version
 
+      - name: rustc
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            profile: minimal
+            override: true
+
       - name: ruby 3.2
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: brew install
         run: |
-          brew update
+          #brew update
           brew install rust
 
       - name: ruby 3.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,22 @@ jobs:
           sudo xcode-select -s '/Applications/Xcode_13.4.1.app/Contents/Developer'
           xcodebuild -version
 
-      - name: brew install
-        run: |
-          #brew update
-          brew install rust
-
       - name: ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
+
+      - name: setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile:   minimal
+          toolchain: stable
+          default:   true
+          override:  true
+
+      - name: setup rust targets
+        run: |
+          rustup target list | grep apple | grep -v '(installed)' | xargs rustup target add
 
       - name: build
         run: rake build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
           ruby-version: 3.2
 
       - name: build
-        run: rustc --version #rake build
+        run: rake build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,10 @@ jobs:
           sudo xcode-select -s '/Applications/Xcode_13.4.1.app/Contents/Developer'
           xcodebuild -version
 
-      - name: rustc
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            profile: minimal
-            override: true
+      - name: brew install
+        run: |
+          brew update
+          brew install rust
 
       - name: ruby 3.2
         uses: ruby/setup-ruby@v1
@@ -27,4 +25,4 @@ jobs:
           ruby-version: 3.2
 
       - name: build
-        run: rake build
+        run: rustc --version #rake build

--- a/Rakefile
+++ b/Rakefile
@@ -54,6 +54,22 @@ def ruby25_or_higher? ()
   version_string(*CRuby.ruby_version) >= version_string(2, 5)
 end
 
+def to_rust_target (os, sdk, arch)
+  arch = arch.to_s.sub /^arm/, 'aarch'
+  os   = {
+    macosx:          'darwin',
+    iphonesimulator: 'ios-sim',
+    iphoneos:        'ios'
+  }[sdk.to_sym] or raise 'unknown sdk'
+
+  installed_rust_targets.find {|target| target == "#{arch}-apple-#{os}"}
+end
+
+def installed_rust_targets ()
+  @installed_rust_targets ||=
+    (`rustup target list --installed 2>/dev/null` rescue "").lines chomp: true
+end
+
 
 NAME = "CRuby"
 
@@ -196,6 +212,24 @@ file RUBY_CONFIGURE do
         int r = system(buf);
       #else
         int r = -1;
+      #endif
+    TO
+  end
+
+  # use sys_icache_invalidate() on iphoneos
+  modify_file "#{RUBY_DIR}/yjit.c" do |s|
+    <<~HEADER + s.gsub(<<~FROM, <<~TO)
+      #include <TargetConditionals.h>
+      #if TARGET_OS_IOS && !TARGET_OS_SIMULATOR
+      #include <libkern/OSCacheControl.h>
+      #endif
+    HEADER
+      __builtin___clear_cache(start, end);
+    FROM
+      #if TARGET_OS_IOS && !TARGET_OS_SIMULATOR
+        sys_icache_invalidate(start, (size_t) ((char*) end - (char*) start));
+      #else
+        __builtin___clear_cache(start, end);
       #endif
     TO
   end
@@ -347,9 +381,13 @@ TARGETS.each do |os, sdk, archs|
       makefile_dep << BASE_RUBY if BASE_RUBY
       file makefile => makefile_dep do
         chdir ruby_dir do
-          disables = %w[shared dln install-doc]
-          withouts = %w[tcl tk fiddle bigdecimal]
-          nofuncs  = %w[backtrace system syscall __syscall getentropy]
+          rustc_target = to_rust_target os, sdk, arch
+          yjit         = rustc_target != nil
+
+          enables      = yjit ? %w[jit-support yjit] : []
+          disables     = %w[shared dln install-doc]
+          withouts     = %w[tcl tk fiddle bigdecimal]
+          nofuncs      = %w[backtrace system syscall __syscall getentropy]
 
           envs = {
             PATH:     "#{cc_dir}:#{PATHS}",
@@ -361,14 +399,16 @@ TARGETS.each do |os, sdk, archs|
             CFLAGS:   "#{flags} -fvisibility=hidden",
             CXXFLAGS: "-fvisibility-inline-hidden",
             ASFLAGS:  "#{isysroot}",
-            LDFLAGS:  "#{flags} -L#{sdk_root}/usr/lib -lSystem"
-          }.map {|k, v| "#{k}='#{v}'"}.join ' '
+            LDFLAGS:  "#{flags} -L#{sdk_root}/usr/lib -lSystem -framework Security",
+            RUSTC:    rustc_target&.then {|t| "rustc --target=#{t}"}
+          }.compact.map {|k, v| "#{k}='#{v}'"}.join ' '
           opts = %W[
             --host=#{host}
             --with-static-linked-ext
             --with-openssl-dir=#{ossl_install_dir}
             --with-libyaml-dir=#{yaml_install_dir}
           ]
+          opts += enables.map  {|s| "--enable-#{s}"}
           opts += disables.map {|s| "--disable-#{s}"}
           opts += withouts.map {|s| "--without-#{s}"}
           opts += nofuncs .map {|s| "ac_cv_func_#{s}=no"} if ios
@@ -379,7 +419,9 @@ TARGETS.each do |os, sdk, archs|
 
           modify_file makefile do |s|
             # avoid link error on linking exe/ruby
-            s.gsub /^.*PROGRAM.*:.*exe\/.*PROGRAM.*$/, ''
+            s = s.gsub /^.*PROGRAM.*:.*exe\/.*PROGRAM.*$/, ''
+            s += "$(LIBRUBY_A): $(YJIT_LIBS)" if yjit
+            s
           end
         end
       end

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,10 @@ BUILD_TARGETS = (ENV['targets'] || ENV['target'])&.split(/[ ,]+/)
 #   => do not download prebuild archive.
 NO_PREBUILT   = (ENV['noprebuilt'] || 0).to_i != 0
 
+# $ rake build yjit_stats=1
+#   => same as passing '--yjit-stats' option to 'ruby' command
+YJIT_STATS   = (ENV['yjit_stats'] || 0).to_i != 0
+
 
 def read_file (path)
   open(path) {|f| f.read}
@@ -193,7 +197,7 @@ file RUBY_CONFIGURE do
 
         #if USE_YJIT
           FEATURE_SET(opt.features, FEATURE_BIT(yjit));
-          setup_yjit_options("");
+          setup_yjit_options("#{YJIT_STATS ? 'stats' : ''}");
           opt.yjit = yjit;
         #endif
 
@@ -396,6 +400,7 @@ TARGETS.each do |os, sdk, archs|
         chdir ruby_dir do
           rustc_target = to_rust_target os, sdk, arch
           yjit         = rustc_target != nil
+          flags       += ' -DYJIT_STATS=1' if yjit && YJIT_STATS
 
           enables      = yjit ? %w[jit-support yjit] : []
           disables     = %w[shared dln install-doc]

--- a/Rakefile
+++ b/Rakefile
@@ -347,7 +347,7 @@ TARGETS.each do |os, sdk, archs|
       makefile_dep << BASE_RUBY if BASE_RUBY
       file makefile => makefile_dep do
         chdir ruby_dir do
-          disables = %w[shared dln jit-support install-doc]
+          disables = %w[shared dln install-doc]
           withouts = %w[tcl tk fiddle bigdecimal]
           nofuncs  = %w[backtrace system syscall __syscall getentropy]
 

--- a/Rakefile
+++ b/Rakefile
@@ -402,10 +402,10 @@ TARGETS.each do |os, sdk, archs|
           yjit         = rustc_target != nil
           flags       += ' -DYJIT_STATS=1' if yjit && YJIT_STATS
 
-          enables      = yjit ? %w[jit-support yjit] : []
-          disables     = %w[shared dln install-doc]
-          withouts     = %w[tcl tk fiddle bigdecimal]
-          nofuncs      = %w[backtrace system syscall __syscall getentropy]
+          enables  = yjit ? %w[jit-support yjit] : []
+          disables = %w[shared dln install-doc]
+          withouts = %w[tcl tk fiddle bigdecimal]
+          nofuncs  = %w[backtrace system syscall __syscall getentropy]
 
           envs = {
             PATH:     "#{cc_dir}:#{PATHS}",

--- a/include/CRuby.h
+++ b/include/CRuby.h
@@ -17,7 +17,8 @@ typedef void (^RescueBlock) (CRBValue *exception);
 + (CRBValue *)evaluate:(NSString *)string rescue:(RescueBlock)rescue;
 
 + (void)addLibrary:(NSString *)name bundle:(NSBundle *)bundle;
-
 + (void)addExtension:(NSString *)path init:(void(^)())init;
+
++ (void)enableYJIT;
 
 @end

--- a/src/CRuby.m
+++ b/src/CRuby.m
@@ -42,9 +42,9 @@ static NSMutableDictionary *gExtensions = nil;
 
 	gExtensions = [[NSMutableDictionary alloc] init];
 
-	void CRuby_init(void (*init_prelude)());
+	void CRuby_init(void (*)(), bool);
 	void Init_prelude();
-	CRuby_init(Init_prelude);
+	CRuby_init(Init_prelude, true);
 
 	[self addLibrary:@"CRuby" bundle:[NSBundle bundleForClass:CRuby.class]];
 

--- a/src/CRuby.m
+++ b/src/CRuby.m
@@ -34,7 +34,14 @@ typedef void (^InitBlock) ();
 
 static NSMutableDictionary *gExtensions = nil;
 
-+ (void)initialize
+static BOOL gYJIT = NO;
+
++ (void)finalize
+{
+	ruby_finalize();
+}
+
++ (void)setupCRuby
 {
 	static BOOL done = NO;
 	if (done) return;
@@ -44,7 +51,7 @@ static NSMutableDictionary *gExtensions = nil;
 
 	void CRuby_init(void (*)(), bool);
 	void Init_prelude();
-	CRuby_init(Init_prelude, true);
+	CRuby_init(Init_prelude, gYJIT);
 
 	[self addLibrary:@"CRuby" bundle:[NSBundle bundleForClass:CRuby.class]];
 
@@ -81,11 +88,6 @@ static NSMutableDictionary *gExtensions = nil;
 #else
 	return @"nil";
 #endif
-}
-
-+ (void)finalize
-{
-	ruby_finalize();
 }
 
 + (BOOL)start:(NSString *)filename
@@ -154,6 +156,8 @@ static NSMutableDictionary *gExtensions = nil;
 
 + (CRBValue *)eval:(NSString *)string rescue:(RescueBlock)rescue
 {
+	[self setupCRuby];
+
 	int state = 0;
 	VALUE ret = rb_eval_string_protect(string.UTF8String, &state);
 
@@ -204,6 +208,12 @@ static NSMutableDictionary *gExtensions = nil;
 	((InitBlock) init)();
 	[init release];
 	return YES;
+}
+
++ (void)enableYJIT
+{
+	// must be called before first 'eval' call
+	gYJIT = YES;
 }
 
 @end


### PR DESCRIPTION
YJIT is now enabled where possible.
However, it is disabled by default because we have not yet confirmed its stability.
To enable it, call `CRuby.enableYJIT()` before the first script execution.

As a reference value, I did a quick benchmark with the Fibonacci number calculation.
```
require 'benchmark'

def fib(n)
  n < 2 ? n : fib(n-1) + fib(n-2)
end

Benchmark.bm do |bm|
  bm.report {fib 30}
end
````

Here are the results
> iPhone 13 / YJIT off → 0.058085 sec.
> iPhone 13 / YJIT on → 0.013276 sec.
